### PR TITLE
Core git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* eol=lf
+*.png binary
+*.jpg binary
+*.gif binary
++*.jar binary
++*.exe binary
++*.eot binary
++*.ttf binary
++*.pdf binary


### PR DESCRIPTION
This is a minor improvement for git structure. Normally git can show the git attributes to allow customized diff of binary files.
