### PR TITLE
Bug #900 post_max_size is definied two times in php.ini.temp

### DIFF
--- a/kloxo/file/phpini/php.ini.temp
+++ b/kloxo/file/phpini/php.ini.temp
@@ -16,7 +16,6 @@ mysql.allow_persistent = __lx__mysql_allow_persistent_flag
 max_execution_time = __lx__max_execution_time_flag
 max_input_time = __lx__max_input_time_flag
 memory_limit = __lx__memory_limit_flag
-post_max_size = __lx__post_max_size_flag
 allow_url_fopen = __lx__allow_url_fopen_flag
 allow_url_include = __lx__allow_url_include_flag
 register_long_arrays = __lx__register_long_arrays_flag


### PR DESCRIPTION
Please refer to http://project.lxcenter.org/issues/900 for full details. Work done by Danny and committed by me.
