### PR TITLE
Php 5.4 compatibility fixes

### DIFF
--- a/kloxo/httpdocs/htmllib/lib/client/clientbaselib.php
+++ b/kloxo/httpdocs/htmllib/lib/client/clientbaselib.php
@@ -345,7 +345,7 @@ function createShowAlist(&$alist, $subaction = null)
 
 
 
-function createShowAlistConfig(&$alist)
+function createShowAlistConfig(&$alist, $class=null)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 

--- a/kloxo/httpdocs/htmllib/lib/commonfslib.php
+++ b/kloxo/httpdocs/htmllib/lib/commonfslib.php
@@ -55,7 +55,17 @@ function lxshell_redirect($file, $cmd)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+
 	$cmd = getShellCommand($cmd, $arglist);
 	$return = null;
 	system("$cmd > $file 3</dev/null 4</dev/null 5</dev/null 6</dev/null", $return);
@@ -70,7 +80,16 @@ function lxshell_directory($dir, $cmd)
 	$username = '__system__';
 
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+	
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, $dir, $cmd, $out, $err, $ret, null);
 	return $out;
@@ -84,7 +103,16 @@ function lxshell_output($cmd)
 	$username = '__system__';
 
 	$start = 1;
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, null, $cmd, $out, $err, $ret, null);
 	return $out;
@@ -96,7 +124,15 @@ function lxshell_return($cmd)
 	$username = '__system__';
 
 	$start = 1;
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
 
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, null, $cmd, $out, $err, $ret, null);
@@ -114,7 +150,16 @@ function lxshell_input($input, $cmd)
 	$username = '__system__';
 
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, null, $cmd, $out, $err, $ret, $input);
 	return $ret;
@@ -268,7 +313,16 @@ function lxuser_return($username, $cmd) {
 	global $sgbl;
 	
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+
 	$cmd = getShellCommand($cmd, $arglist);
 	
 	$ret = new_process_cmd($username, null, $cmd);

--- a/kloxo/httpdocs/htmllib/lib/dns/dnsbaselib.php
+++ b/kloxo/httpdocs/htmllib/lib/dns/dnsbaselib.php
@@ -36,7 +36,7 @@ function updateform($subaction, $param)
 	return $vlist;
 }
 
-function isAction()
+function isAction($var)
 {
 	if ($this->ttype === 'ns') {
 		return false;

--- a/kloxo/httpdocs/htmllib/lib/linuxfslib.php
+++ b/kloxo/httpdocs/htmllib/lib/linuxfslib.php
@@ -611,7 +611,17 @@ function lxshell_background($cmd)
 	global $global_dontlogshell;
 	$username = '__system__';
 	$start = 1;
-	eval($sgbl->arg_getting_string);
+
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+
 	$cmd = getShellCommand($cmd, $arglist);
 	$cmd .= " >/dev/null 2>&1 &";
 	$pwd = getcwd();

--- a/kloxo/httpdocs/htmllib/lib/pserver/cronlib.php
+++ b/kloxo/httpdocs/htmllib/lib/pserver/cronlib.php
@@ -107,7 +107,7 @@ function createExtraVariables()
 }
 
 
-static function  createListNlist($parent)
+static function  createListNlist($parent, $view)
 {
 	//$nlist["nname"] = "5%";
 	//$nlist["minute"] = "5%";

--- a/kloxo/httpdocs/htmllib/lib/pserver/diskusagelib.php
+++ b/kloxo/httpdocs/htmllib/lib/pserver/diskusagelib.php
@@ -37,7 +37,7 @@ Function display($var)
 
 
 
-static  function createListNlist($parent)
+static  function createListNlist($parent, $view)
 {
 	$nlist["nname"] = "100%";
 	$nlist["used"] = "15%";

--- a/kloxo/httpdocs/htmllib/lib/windowsfslib.php
+++ b/kloxo/httpdocs/htmllib/lib/windowsfslib.php
@@ -138,7 +138,16 @@ function lxshell_background($cmd)
 	global $gbl, $sgbl, $login, $ghtml; 
 	$username = '__system__';
 	$start = 1;
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+
 	$cmd = getShellCommand($cmd, $arglist);
 	$sh = new COM("Wscript.shell");
 	$cmdobject = $sh->Run($cmd, 1);

--- a/kloxo/httpdocs/htmllib/phplib/lib/generallib.php
+++ b/kloxo/httpdocs/htmllib/phplib/lib/generallib.php
@@ -8,7 +8,7 @@ class helpdeskcategory_a extends Lxaclass {
 	static $__desc_nname =  array("", "",  "category");
 
 
-static function createListAlist($parent)
+static function createListAlist($parent, $class)
 {
 	$nalist = ticket::createListAlist($parent, 'ticket');
 	foreach($nalist as $a) {

--- a/kloxo/httpdocs/htmllib/phplib/lib/lxclass.php
+++ b/kloxo/httpdocs/htmllib/phplib/lib/lxclass.php
@@ -512,7 +512,24 @@ final static function calldriverappFunc($class, $func)
 
 	$start = 2;
 
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
 
 
 	return call_user_func_array(array($class, $func), $arglist);
@@ -3821,7 +3838,7 @@ function getSpecialParentClass()
 	return 'client';
 }
 function createShowIlist() { return null; }
-static function AddListForm() { return null; }
+static function AddListForm($parent, $class) { return null; }
 
 function createShowPropertyList(&$alist) { $alist['property'][] = 'a=show';}
 function createShowActionList(&$alist) { }

--- a/kloxo/httpdocs/htmllib/phplib/lib/sgbllib.php
+++ b/kloxo/httpdocs/htmllib/phplib/lib/sgbllib.php
@@ -5,6 +5,8 @@ class Sgbllib {
 function __construct()
 {
 
+
+	// OA 20140118: To be removed, not compatible with php 5.4
 	$this->arg_getting_string = '
 	$arglist = array();
 	for ($i = $start; $i < func_num_args(); $i++) {

--- a/kloxo/httpdocs/htmllib/phplib/lxlib.php
+++ b/kloxo/httpdocs/htmllib/phplib/lxlib.php
@@ -653,7 +653,15 @@ function lx_merge_good($arg)
 	$start = 0;
 	$transforming_func = null;
 
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
 
 	//dprintr($arglist);
 
@@ -952,7 +960,15 @@ function lx_redefine_func($func)
 	$start = 1;
 	$transforming_func = "expand_real_root";
 
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
 
 	return call_user_func_array($func, $arglist);
 }
@@ -2726,7 +2742,15 @@ function exec_class_method($class, $func)
 	//Arg getting string is a function that needs $start to be set.
 	$start = 2;
 
-	eval($sgbl->arg_getting_string);
+        $arglist = array();
+        for ($i = $start; $i < func_num_args(); $i++) {
+                if (isset($transforming_func)) {
+                        $arglist[] = $transforming_func(func_get_arg($i));
+                } else {
+                        $arglist[] = func_get_arg($i);
+                }
+        }
+
 
 	// workaround for the following php bug:
 	//   http://bugs.php.net/bug.php?id=47948

--- a/kloxo/httpdocs/lib/domain/clientmail.php
+++ b/kloxo/httpdocs/lib/domain/clientmail.php
@@ -12,7 +12,7 @@ function write() {}
 function doSyncToSystem() {}
 
 
-static function createListNlist($parent)
+static function createListNlist($parent, $class)
 {
 	$nlist['clientname'] = '100%';
 	$nlist['mailnum'] = '10%';

--- a/kloxo/httpdocs/lib/domain/domainlib.php
+++ b/kloxo/httpdocs/lib/domain/domainlib.php
@@ -1555,7 +1555,7 @@ function createShowUpdateform()
 }
 
 function hasFunctions() { return true; }
-function createShowAlistConfig(&$alist)
+function createShowAlistConfig(&$alist, $subaction=null)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 	$alist['__title_advanced'] = $login->getKeywordUc('advanced');

--- a/kloxo/httpdocs/lib/domain/mmail/mailfilter.php
+++ b/kloxo/httpdocs/lib/domain/mmail/mailfilter.php
@@ -12,7 +12,7 @@ static $__desc_rule  	 = array("", "",  "rule");
 static $__desc_action  	 = array("", "",  "action");
 static $__rewrite_nname_const =    Array("parent_clname", "rule");
 
-function createListNlist()
+function createListNlist($parent, $class)
 {
 	$nlist['rule'] = '100%';
 	$nlist['action'] = null;

--- a/kloxo/httpdocs/lib/domain/web/mimehandler.php
+++ b/kloxo/httpdocs/lib/domain/web/mimehandler.php
@@ -6,7 +6,7 @@ class mimehandler extends lxdb {
 
 static $__desc_extension	 = array("n", "",  "extension(s)");
 
-static function createListNlist($parent)
+static function createListNlist($parent, $class)
 {
 	$nlist['mimehandler'] = '100%';
 	$nlist['extension'] = '10%';


### PR DESCRIPTION
Behaviour of eval() changed since php 5.2, changed arg_getting_strings to inline.
Fixed E_STRICT fails because of inconsistent function declarations.
