### PR TITLE
Added Bind IPv6 rekord creation support

### DIFF
--- a/kloxo/httpdocs/htmllib/lib/dns/driver/dns__djbdnslib.php
+++ b/kloxo/httpdocs/htmllib/lib/dns/driver/dns__djbdnslib.php
@@ -51,6 +51,10 @@ function syncAddFile($domainname)
 	$starvalue = null;
 	$dnsdata = null;
 	$nameserver = null;
+
+	// #772 - Add TTL Support
+	$ttl=$this->main->ttl;
+
 	foreach($dnsrec as $dns) {
 		if ($dns->ttype === "ns") {
 			if (!$nameserver) {


### PR DESCRIPTION
TODO:
    - handle **base6** when checking IP
    - add IPv6 MX, NS, AAAA etc to DNS templates
    - automaticly add AAAA when creating domain
    - Domain's apache/lighttpd config creation
    - IPv6 PTR record?
TODO IPv6 Global:
    - Enalbe kloxo to listen on IPv6 (hint: hypervm is ready for that)
        - upgrade sbin c sources
        - change kloxo ligthy config
        - php listen on ipv6 socket
It is highly unlikely that I'd do this, just wanted to help with summing up.
