### PR TITLE
Fix Select One PHP issue

### DIFF
--- a/kloxo/httpdocs/htmllib/lib/objectactionlib.php
+++ b/kloxo/httpdocs/htmllib/lib/objectactionlib.php
@@ -411,7 +411,7 @@ function do_desc_update($object, $subaction, $param)
 		return false;
 	}
 
-	if (array_search_bool('--Select One--', $param)) {
+	if (array_search_bool('--Select One--', $param, true)) {
 		throw new lxException("Select One is not an acceptable Value", '');
 	}
 


### PR DESCRIPTION
```
            // OA Left this here so you see why Ive added 'strict' to array_search
            // Basically 1 = '--Select One--' without strict search
            //
            // Anyone knows where else could 'strict' be needed?
            //
            //$ret = array_search('--Select One--', $param, true);
            //if($param[$ret] == '--Select One--') $str_ = $param[$ret] ."  equals --Select One-- according to php...";
```
