### PR TITLE
Dkim higher sec key and new TLDs

### DIFF
--- a/kloxo/bin/fix/domainkey.php
+++ b/kloxo/bin/fix/domainkey.php
@@ -10,7 +10,7 @@ $list = $login->getList('client');
 foreach($list as $c) {
 	$dlist = $c->getList('domaina');
 	foreach((array) $dlist as $l) {
-		$l->generateDomainKey(false);
+		$l->generateDomainKey(false, true);
 	}
 }
 

--- a/kloxo/httpdocs/htmllib/lib/lib.php
+++ b/kloxo/httpdocs/htmllib/lib/lib.php
@@ -876,7 +876,7 @@ function validate_domain_name($name)
 		throw new lxException('add_without_www', 'nname');
 	}
 
-	if(!preg_match('/^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+(([a-z]{2,6})|(xn--[a-z0-9]{4,14}))$/i', $name)) {
+	if(!preg_match('/^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+(([a-z]{2,9})|(xn--[a-z0-9]{4,14}))$/i', $name)) {
 		throw new lxException('invalid_domain_name', 'nname');
 	}
 	

--- a/kloxo/httpdocs/htmllib/lib/lib.php
+++ b/kloxo/httpdocs/htmllib/lib/lib.php
@@ -1331,7 +1331,7 @@ function do_actionlog($login, $object, $action, $subaction)
 function validate_email($email)
 {
 	$regexp = "/^([\w\!\#$\%\&\'\*\+\-\/\=\?\^\`{\|\}\~]+\.)*[\w\!\#$\%\&\'\*\+\-\/\=\?\^\`{\|\}\~]+@" .
-		"((((([a-z0-9]{1}[a-z0-9\-]{0,62}[a-z0-9]{1})|[a-z])\.)+[a-z]{2,6})|(\d{1,3}\.){3}\d{1,3}(\:\d{1,5})?)$/i";
+		"((((([a-z0-9]{1}[a-z0-9\-]{0,62}[a-z0-9]{1})|[a-z])\.)+[a-z]{2,9})|(\d{1,3}\.){3}\d{1,3}(\:\d{1,5})?)$/i";
 	if(!preg_match($regexp, $email)) {
 		return false;
 	}

--- a/kloxo/httpdocs/lib/domain/domainlib.php
+++ b/kloxo/httpdocs/lib/domain/domainlib.php
@@ -845,7 +845,7 @@ function postAdd()
 
 }
 
-function generateDomainKey($dontwasflag)
+function generateDomainKey($dontwasflag, $forceGen= false)
 {
 
 	global $gbl, $sgbl, $login, $ghtml; 
@@ -864,7 +864,7 @@ function generateDomainKey($dontwasflag)
 		return;
 	}
 
-	$dkey = rl_exec_in_driver($mmail, 'mmail', 'generateDKey', array($this->nname));
+	$dkey = rl_exec_in_driver($mmail, 'mmail', 'generateDKey', array($this->nname, $forceGen));
 
 	if (!$dkey) { return; }
 

--- a/kloxo/httpdocs/lib/domain/mmail/driver/mmail__qmaillib.phps
+++ b/kloxo/httpdocs/lib/domain/mmail/driver/mmail__qmaillib.phps
@@ -37,7 +37,7 @@ static function generateDKey($domain)
 		return null;
 	}
 
-	lxshell_return("openssl", "genrsa", "-out", "private", 384);
+	lxshell_return("openssl", "genrsa", "-out", "private", 2048);
 
 	$tfile = lx_tmp_file("rsagen");
 

--- a/kloxo/httpdocs/lib/domain/mmail/driver/mmail__qmaillib.phps
+++ b/kloxo/httpdocs/lib/domain/mmail/driver/mmail__qmaillib.phps
@@ -14,16 +14,17 @@ function do_backup()
 	return array($mailpath, $list);
 }
 
-static function generateDKey($domain)
+static function generateDKey($domain, $forceGen=false)
 {
 
 	$pfile = "/var/qmail/control/domainkeys/$domain/public.txt";
 	if (!$domain) {
 		return;
 	}
-	if(lxfile_exists("/var/qmail/control/domainkeys/$domain/public.txt")) {
-		return lfile_get_contents("/var/qmail/control/domainkeys/$domain/public.txt");
-	}
+	if(!$forceGen)
+		if(lxfile_exists("/var/qmail/control/domainkeys/$domain/public.txt")) {
+			return lfile_get_contents("/var/qmail/control/domainkeys/$domain/public.txt");
+		}
 
 	lxfile_mkdir("/var/qmail/control/domainkeys/$domain");
 


### PR DESCRIPTION
Changed tld check to accept new, longer TLDs.

Changed domainkey openssl rsa generation to 2048bits.
Added forceGen flag to generateDKey(), so the fix/domainkey.php can be used to regenerate old keys. 